### PR TITLE
Add AST 4-level organizational hierarchy to the catalog

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -13,6 +13,8 @@ backend:
   #   keys:
   #     - secret: ${BACKEND_SECRET}
   baseUrl: http://localhost:7007
+  logger:
+    level: warn
   listen:
     port: 7007
     # Uncomment the following host directive to bind to specific interfaces

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -155,6 +155,13 @@ catalog:
     - type: file
       target: ../../catalog/seed/system-aragon-idp.yaml
 
+    # Jerarquia organizativa AST de 4 niveles (ADR-0002 / ADR-0005 / ADR-0007):
+    # 8 Group estaticos (organization, business-unit, product-area). Los team
+    # del nivel 4 siguen viniendo de Keycloak; las relaciones childOf/parentOf
+    # se derivan de los spec.children declarados en los padres.
+    - type: file
+      target: ../../catalog/seed/org-ast.yaml
+
     - type: file
       target: ../../catalog-info.yaml
 

--- a/catalog/seed/org-ast.yaml
+++ b/catalog/seed/org-ast.yaml
@@ -1,0 +1,132 @@
+# Jerarquía organizativa AST de 4 niveles (ADR-0002 / ADR-0005 / ADR-0007).
+#
+# Nodos estáticos: 1 organization (ast), 3 business-unit (desarrollo,
+# plataforma, seguridad) y 4 product-area (desarrollo-web, desarrollo-backend,
+# sre, gobierno-datos). Solo declaran `spec.children`, nunca `spec.members`
+# (ADR-0004): la afiliación a un nodo padre se calcula automáticamente por
+# jerarquía como la unión de los miembros de sus hijos.
+#
+# Los `team` del nivel 4 (equipo-frontend, equipo-spring, platform-admins,
+# security-reviewers) NO se redefinen aquí: se sincronizan desde Keycloak vía
+# catalog.providers.keycloakOrg. Las relaciones childOf/parentOf se derivan de
+# los `spec.children` declarados en los padres estáticos: el
+# BuiltinKindsEntityProcessor emite parentOf (padre -> hijo) y, recíprocamente,
+# childOf (hijo -> padre) a partir de esta única declaración.
+---
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: ast
+  description: |
+    Agencia de Servicios Telemáticos (AST). Organización pública ficticia
+    responsable del entorno del demostrador IDP del Gobierno de Aragón.
+    Raíz de la jerarquía organizativa de 4 niveles del catálogo.
+spec:
+  type: organization
+  profile:
+    displayName: AST
+  children:
+    - desarrollo
+    - plataforma
+    - seguridad
+---
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: desarrollo
+  description: |
+    Business unit de desarrollo de software bajo AST. Agrupa las áreas de
+    producto de frontend y backend.
+spec:
+  type: business-unit
+  profile:
+    displayName: Desarrollo
+  children:
+    - desarrollo-web
+    - desarrollo-backend
+---
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: plataforma
+  description: |
+    Business unit de plataforma bajo AST. Agrupa el área de producto SRE,
+    responsable de la operación y el gobierno de la infraestructura del IDP.
+spec:
+  type: business-unit
+  profile:
+    displayName: Plataforma
+  children:
+    - sre
+---
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: seguridad
+  description: |
+    Business unit de seguridad bajo AST. Agrupa el área de producto de
+    gobierno de datos, responsable de la revisión de seguridad y la postura
+    ENS del catálogo.
+spec:
+  type: business-unit
+  profile:
+    displayName: Seguridad
+  children:
+    - gobierno-datos
+---
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: desarrollo-web
+  description: |
+    Área de producto de desarrollo web bajo la business unit Desarrollo.
+    Agrupa al equipo operativo equipo-frontend (sincronizado desde Keycloak).
+spec:
+  type: product-area
+  profile:
+    displayName: Desarrollo Web
+  children:
+    - equipo-frontend
+---
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: desarrollo-backend
+  description: |
+    Área de producto de desarrollo backend bajo la business unit Desarrollo.
+    Agrupa al equipo operativo equipo-spring (sincronizado desde Keycloak).
+spec:
+  type: product-area
+  profile:
+    displayName: Desarrollo Backend
+  children:
+    - equipo-spring
+---
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: sre
+  description: |
+    Área de producto SRE bajo la business unit Plataforma. Agrupa al equipo
+    operativo platform-admins (sincronizado desde Keycloak).
+spec:
+  type: product-area
+  profile:
+    displayName: SRE
+  children:
+    - platform-admins
+---
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: gobierno-datos
+  description: |
+    Área de producto de gobierno de datos bajo la business unit Seguridad.
+    Agrupa al equipo operativo security-reviewers (sincronizado desde
+    Keycloak).
+spec:
+  type: product-area
+  profile:
+    displayName: Gobierno de Datos
+  children:
+    - security-reviewers

--- a/catalog/seed/system-aragon-idp.yaml
+++ b/catalog/seed/system-aragon-idp.yaml
@@ -13,5 +13,7 @@ metadata:
     - idp
     - plataforma
     - desy
+  annotations:
+    aragon.es/security-owner: group:default/security-reviewers
 spec:
   owner: group:platform-admins

--- a/catalog/seed/system-portal-ciudadano.yaml
+++ b/catalog/seed/system-portal-ciudadano.yaml
@@ -2,9 +2,13 @@
 # dos Components conectados por partOf y dependsOn, listo para validar el
 # grafo del catalog-graph (RC-SYS-03) durante un arranque limpio.
 #
-# Los 3 Group de roles (developers, platform-admins, security-reviewers)
-# vienen sincronizados desde Keycloak vía catalog.providers.keycloakOrg
-# (RC-UG-01) — no se duplican como YAML estático aquí.
+# Los teams operativos (equipo-frontend, equipo-spring, platform-admins,
+# security-reviewers) se sincronizan desde Keycloak vía
+# catalog.providers.keycloakOrg (RC-UG-01) y cuelgan de la jerarquía AST
+# de 4 niveles definida en catalog/seed/org-ast.yaml (ADR-0005/0007) — no
+# se duplican como YAML estático aquí. Cada entidad distingue propietario
+# técnico (spec.owner) y responsable de seguridad
+# (aragon.es/security-owner, ADR-0008).
 ---
 apiVersion: backstage.io/v1alpha1
 kind: System
@@ -17,6 +21,8 @@ metadata:
   tags:
     - ciudadano
     - desy
+  annotations:
+    aragon.es/security-owner: group:default/security-reviewers
 spec:
   owner: group:platform-admins
 ---
@@ -32,9 +38,11 @@ metadata:
     - ciudadano
     - desy
     - frontend
+  annotations:
+    aragon.es/security-owner: group:default/security-reviewers
 spec:
   type: website
-  owner: group:developers
+  owner: group:equipo-frontend
   lifecycle: production
   system: portal-ciudadano
   dependsOn:
@@ -51,9 +59,11 @@ metadata:
   tags:
     - ciudadano
     - backend
+  annotations:
+    aragon.es/security-owner: group:default/security-reviewers
 spec:
   type: service
-  owner: group:developers
+  owner: group:equipo-frontend
   lifecycle: production
   system: portal-ciudadano
   consumesApis:

--- a/docs/adr/0001-modelo-organizativo-ast.md
+++ b/docs/adr/0001-modelo-organizativo-ast.md
@@ -1,0 +1,21 @@
+# ADR-0001: Modelo Organizativo AST En El Catalogo
+
+## Estado
+
+Aceptada
+
+## Contexto
+
+El prototipo Backstage incluye usuarios y grupos operativos sincronizados desde Keycloak, pero no representa una organizacion publica responsable como raiz del modelo de gobierno. Esto debilita la explicacion de ownership, trazabilidad y responsabilidad institucional en el catalogo.
+
+## Decision
+
+Modelar AST como organizacion publica ficticia responsable del portal y raiz conceptual del modelo organizativo en Backstage Catalog.
+
+Keycloak seguira representando el directorio corporativo y la fuente maestra de usuarios y grupos operativos. Backstage no sustituye al directorio corporativo: actua como una proyeccion de gobierno para catalogo, ownership, permisos, auditoria y trazabilidad.
+
+## Consecuencias
+
+- El catalogo podra mostrar una organizacion responsable del demostrador, no solo roles operativos planos.
+- Las identidades corporativas seguiran dependiendo de Keycloak o del sistema equivalente en un despliegue real.
+- Las futuras decisiones de implementacion deberan evitar duplicar usuarios o grupos operativos ya sincronizados desde el directorio corporativo.

--- a/docs/adr/0002-jerarquia-minima-ast.md
+++ b/docs/adr/0002-jerarquia-minima-ast.md
@@ -1,0 +1,28 @@
+# ADR-0002: Implementar Jerarquia Minima AST En El Catalogo
+
+## Estado
+
+Aceptada
+
+## Contexto
+
+El tutor senala que el prototipo no muestra una organizacion responsable en el catalogo. ADR-0001 fija AST como raiz conceptual, pero no decide si esa jerarquia se materializa en el artefacto o solo en la memoria.
+
+## Decision
+
+Implementar una jerarquia minima y demostrable de AST en el catalogo Backstage:
+
+```text
+ast
+├── plataforma
+├── desarrollo
+└── seguridad
+```
+
+La jerarquia se anade como entidades estaticas de catologo. No se modifican usuarios, permisos ni anotaciones ENS en esta iteracion.
+
+## Consecuencias
+
+- El catalogo mostrara una organizacion responsable visible, no solo roles operativos planos.
+- Habra que investigar como los grupos estaticos YAML conviven con los grupos sincronizados desde Keycloak sin duplicar entidades.
+- La jerarquia podra ampliarse despues con subunidades, ownership.setToolTip o relaciones adicionales.

--- a/docs/adr/0003-grupos-keycloak-hijos-ast.md
+++ b/docs/adr/0003-grupos-keycloak-hijos-ast.md
@@ -1,0 +1,38 @@
+# ADR-0003: Grupos Operativos Keycloak Como Hijos De Unidades AST
+
+## Estado
+
+Superseded by ADR-0005 (jerarquía de 2 niveles reemplazada por jerarquía de 4 niveles).
+
+## Contexto
+
+ADR-0002 define una jerarquia minima AST con tres unidades funcionales (`plataforma`, `desarrollo`, `seguridad`). Existen ademas tres grupos operativos sincronizados desde Keycloak (`developers`, `platform-admins`, `security-reviewers`) que actualmente son planos, sin padre organizativo.
+
+La investigacion tecnica confirma que el provider de Keycloak reescribe los campos `spec` de sus grupos cada 30 minutos y no popula `spec.parent`. Redefinir esos grupos en YAML estatico provocaria sobrescrituras alternantes e inestabilidad. La via segura es declarar `spec.children` unicamente en los grupos estaticos padre.
+
+## Decision
+
+Anadir un segundo nivel a la jerarquia AST donde los grupos operativos de Keycloak cuelgan como hijos de las unidades funcionales:
+
+```text
+ast
+├── plataforma
+│   └── platform-admins    (Keycloak)
+├── desarrollo
+│   └── developers         (Keycloak)
+└── seguridad
+    └── security-reviewers (Keycloak)
+```
+
+Implementacion:
+
+- Los grupos estaticos (`ast`, `plataforma`, `desarrollo`, `seguridad`) se definen en YAML estatico con `spec.children` apuntando a sus hijos.
+- Los grupos operativos (`developers`, `platform-admins`, `security-reviewers`) no se redefinen en YAML: siguen viniendo unicamente desde Keycloak.
+- Las relaciones `childOf` / `parentOf` se derivan automaticamente desde `spec.children` en el lado del padre estatico.
+
+## Consecuencias
+
+- El catalogo mostrara la cadena de gobierno completa: organizacion publica -> unidad funcional -> equipo operativo.
+- No se duplican entidades ni se interfiere con la sincronizacion de Keycloak.
+- Si en el futuro se anaden mas grupos operativos en Keycloak, habra que decidir bajo que unidad funcional cuelgan.
+- El modelo asume una correspondencia uno-a-uno unidad funcional <-> grupo operativo. Si eso cambia, habra que revisar la jerarquia.

--- a/docs/adr/0004-nodos-ast-sin-usuarios-directos.md
+++ b/docs/adr/0004-nodos-ast-sin-usuarios-directos.md
@@ -1,0 +1,25 @@
+# ADR-0004: Nodos Organizativos AST Sin Usuarios Directos
+
+## Estado
+
+Aceptada
+
+## Contexto
+
+ADR-0003 coloca los grupos operativos de Keycloak como hijos de las unidades funcionales AST. Queda por decidir si los nodos organizativos (`ast`, `plataforma`, `desarrollo`, `seguridad`) deben listar usuarios propios ademas de sus grupos hijos.
+
+Los usuarios reales ya estan asignados a los grupos operativos en Keycloak (`keycloak/realm-export/aragon-idp-realm.json`, campo `"groups"` por usuario). El plugin sincroniza esa asignacion al catalogo.
+
+## Decision
+
+Los nodos organizativos AST (`ast`, `plataforma`, `desarrollo`, `seguridad`) seran nodos estructurales sin usuarios directos. Solo declaran `spec.children`, nunca `spec.members`.
+
+La afiliacion a un nodo padre se calcula automaticamente por jerarquia: Backstage muestra como miembros de un grupo padre a todos los miembros de sus grupos hijos.
+
+## Consecuencias
+
+- Cero mantenimiento manual de listas de usuarios en YAML estatico.
+- Anadir o remover usuarios en Keycloak se refleja automaticamente en la jerarquia AST sin tocar Backstage.
+- El modelo asume que toda persona pertenece a un equipo operativo concreto. No representa pertenencia generica a una unidad funcional sin equipo especifico.
+- La permission-policy existente no se ve afectada: sigue mapeando por grupos operativos, no por unidades funcionales.
+- Si en el futuro se necesita representar jefatura o pertenencia transversal, habra que introducir grupos adicionales.

--- a/docs/adr/0005-jerarquia-4-niveles.md
+++ b/docs/adr/0005-jerarquia-4-niveles.md
@@ -1,0 +1,57 @@
+# ADR-0005: Jerarquia AST De 4 Niveles Con Vocabulario De Gobierno
+
+## Estado
+
+Aceptada
+
+## Contexto
+
+El tutor pide explicitamente una jerarquia organizativa con tipos de unidad diferenciados (team, product-area, business-unit, root) que permita explicar gobierno: permisos, golden paths, flujos de revision y trazabilidad. ADR-0003 definia solo 2 niveles (unidad funcional -> equipo operativo), insuficiente para demonstrar el modelo de gobernanza que el tutor describe.
+
+Para que la jerarquia de 4 niveles tenga masa real y no sea cascaras vacias con un solo hijo cada una, se anaden usuarios y equipos de demostracion a Keycloak.
+
+## Decision
+
+Adoptar una jerarquia de 4 niveles con el vocabulario del tutor:
+
+```text
+ast: organization
+├── desarrollo: business-unit
+│   ├── desarrollo-web: product-area
+│   │   └── equipo-frontend: team        — jperez, mgarcia (Keycloak)
+│   └── desarrollo-backend: product-area
+│       └── equipo-spring: team          — 2 usuarios nuevos (Keycloak)
+├── plataforma: business-unit
+│   └── sre: product-area
+│       └── platform-admins: team        — agarcia (Keycloak)
+└── seguridad: business-unit
+    └── gobierno-datos: product-area
+        └── security-reviewers: team     — msanchez, mgarcia (Keycloak)
+```
+
+Vocabulario de `spec.type`:
+
+| Nivel | `spec.type` | Ejemplo |
+|---|---|---|
+| 1 | `organization` | `ast` |
+| 2 | `business-unit` | `desarrollo`, `plataforma`, `seguridad` |
+| 3 | `product-area` | `desarrollo-web`, `desarrollo-backend`, `sre`, `gobierno-datos` |
+| 4 | `team` | `equipo-frontend`, `equipo-spring`, `platform-admins`, `security-reviewers` |
+
+Implementacion:
+
+- Nodos estaticos YAML (`ast`, `business-unit`, `product-area`): declaran `spec.children`, sin usuarios directos (ADR-0004).
+- Nodos `team`: siguen viniendo de Keycloak, no se redefinen en YAML (ADR-0001, ADR-0003).
+- Los grupos `developers` se renombra a `equipo-frontend` en Keycloak.
+- Se anade `equipo-spring` con 2 usuarios nuevos en Keycloak.
+
+## Consecuencias
+
+- Reemplaza ADR-0003 (jerarquia de 2 niveles) por una jerarquia de 4 niveles alineada con el vocabulario del tutor.
+- Impacto en cascada:
+  - `keycloak/realm-export/aragon-idp-realm.json`: renombrar `developers` -> `equipo-frontend`, anadir `equipo-spring`, anadir 2 usuarios.
+  - `packages/backend/src/permission-policy.ts`: actualizar mapeo `group:default/developers` -> `group:default/equipo-frontend`, anadir `equipo-spring`.
+  - `CODEOWNERS` y `catalog-info.yaml` en plantillas: actualizar referencias.
+  - `docs/keycloack/catalog-sync-flow-visual.md`: actualizar documentacion.
+- El modelo es capaz de soportar mas equipos por product-area si el demostrador crece.
+- La memoria puede explicar que el modelo soporta jerarquias profundas y se ha simplificado a 4 niveles para el demostrador.

--- a/docs/adr/0006-cambios-cascada-renombrado.md
+++ b/docs/adr/0006-cambios-cascada-renombrado.md
@@ -1,0 +1,50 @@
+# ADR-0006: Cambios En Cascada Del Renombrado De Equipos
+
+## Estado
+
+Aceptada
+
+## Contexto
+
+ADR-0005 redefine la jerarquia organizativa con 4 niveles y renombra `developers` a `equipo-frontend`, anade `equipo-spring` con 2 usuarios nuevos, y mantiene `platform-admins` y `security-reviewers`. Esto requiere cambios en cascada en varios ficheros del repositorio.
+
+## Decisiones
+
+### Usuarios nuevos de equipo-spring
+
+Anadir 2 usuarios a Keycloak:
+
+| Username | Nombre | Email | Grupo |
+|---|---|---|---|
+| `lruiz` | Laura Ruiz | `lruiz@aragon.es` | `/equipo-spring` |
+| `jgomez` | Javier Gomez | `jgomez@aragon.es` | `/equipo-spring` |
+
+Credenciales `changeme`, consistentes con los usuarios existentes.
+
+### mgarcia en multiples equipos
+
+Mantener a `mgarcia` en `/equipo-frontend` y `/security-reviewers`. Demuestra que una persona puede pertenecer a equipos operativos en unidades funcionales distintas.
+
+### Ownership de entidades a nivel team
+
+El `spec.owner` de entidades del catalogo (`System`, `Component`, `API`, `Resource`) apunta al `team` concreto, no a `business-unit` o `product-area`. La jerarquia permite inferir la cadena de gobierno sin necesidad de apuntar mas arriba.
+
+### CODEOWNERS por plantilla
+
+- `frontend-angular-desy`: `* @equipo-frontend`
+- `backend-spring-boot`: `* @equipo-spring`
+
+### Valores por defecto de plantillas
+
+- `backend-spring-boot/template.yaml`: `owner: group:default/equipo-spring`
+- `frontend-angular-desy/template.yaml`: `owner: group:default/equipo-frontend`
+- `desy-project/template.yaml`: `owner: user:guest` (sin cambio, plantilla de ejemplo)
+
+## Consecuencias
+
+- `keycloak/realm-export/aragon-idp-realm.json`: renombrar `developers` -> `equipo-frontend`, anadir `equipo-spring`, anadir `lruiz` y `jgomez`, actualizar `mgarcia`.
+- `packages/backend/src/permission-policy.ts`: actualizar mapeo de grupos.
+- `examples/templates/*/content/CODEOWNERS`: actualizar referencias.
+- `examples/templates/*/template.yaml`: actualizar valores por defecto.
+- `catalog/seed/system-*.yaml`: revisar referencias a `developers` -> `equipo-frontend`.
+- `docs/keycloack/catalog-sync-flow-visual.md`: actualizar documentacion.

--- a/docs/adr/0007-materializacion-jerarquia.md
+++ b/docs/adr/0007-materializacion-jerarquia.md
@@ -1,0 +1,29 @@
+# ADR-0007: Materializacion De La Jerarquia AST En El Catalogo
+
+## Estado
+
+Aceptada
+
+## Contexto
+
+ADR-0005 define la jerarquia de 4 niveles. Queda por decidir como se materializan los grupos estaticos en el catalogo y como se registran.
+
+## Decisiones
+
+### Fichero unico
+
+Materializar la jerarquia estatica en un solo fichero `catalog/seed/org-ast.yaml` con los 8 grupos estaticos (`ast`, 3 `business-unit`, 4 `product-area`). Los `team` no van en este fichero: siguen viniendo de Keycloak.
+
+### Registro como location
+
+Registrar `catalog/seed/org-ast.yaml` como `catalog.location` de `type: file` en `app-config.yaml`, coherente con los seeds existentes.
+
+### Mapeo de permission-policy
+
+`equipo-frontend` y `equipo-spring` mapean ambos al rol `developer` en `permission-policy.ts`. Ambos son equipos de desarrollo bajo la misma `business-unit`.
+
+## Consecuencias
+
+- La jerarquia AST es visible en el catalogo con un solo fichero de facil revision.
+- Los grupos estaticos no interfieren con la sincronizacion de Keycloak (ADR-0001, ADR-0003).
+- La permission-policy actualiza el mapeo de grupos operativos.

--- a/docs/adr/0008-anotacion-security-owner.md
+++ b/docs/adr/0008-anotacion-security-owner.md
@@ -1,0 +1,55 @@
+# ADR-0008: Anotacion security-owner Para Gobernanza De Seguridad
+
+## Estado
+
+Aceptada
+
+## Contexto
+
+El tutor pide distinguir la responsabilidad de seguridad del propietario tecnico. En administracion publica, el responsable de seguridad no siempre coincide con el propietario tecnico. Actualmente el catalogo usa un unico `spec.owner` sin distinguir dimensiones de propiedad.
+
+## Decisiones
+
+### Anotacion security-owner
+
+Anadir la anotacion `aragon.es/security-owner` a las entidades del catalogo para representar el responsable de seguridad, distinto del propietario tecnico (`spec.owner`).
+
+```yaml
+metadata:
+  annotations:
+    aragon.es/security-owner: group:default/security-reviewers
+spec:
+  owner: group:default/equipo-frontend
+```
+
+### Valor por defecto
+
+Todas las entidades del catalogo y todas las plantillas usan `group:default/security-reviewers` como valor por defecto de `security-owner`.
+
+### Aplicacion
+
+- Plantillas `backend-spring-boot` y `frontend-angular-desy`: generar `aragon.es/security-owner` en los `catalog-info.yaml`.
+- Entidades existentes en `catalog/seed/`: anadir la anotacion a `system-aragon-idp`, `system-portal-ciudadano`, `portal-ciudadano-frontend`, `portal-ciudadano-backend`.
+
+### No consumo por plugin
+
+La anotacion no se consume con un plugin activo en el prototipo. Se justifica en la memoria:
+
+```text
+La anotacion aragon.es/security-owner se genera en los catalog-info.yaml
+como metadato de gobernanza. En el prototipo no se consume con un plugin
+activo porque el alcance se centra en el modelo organizativo y el catalogo.
+Una extension natural seria un plugin que alerte cuando un componente
+carezca de security-owner, especialmente en recursos importados de GitLab.
+```
+
+### Otras dimensiones de propiedad fuera de alcance
+
+Propiedad funcional, legal y operativa no se modelan en el prototipo. Solo se distingue propietario tecnico (`spec.owner`) y responsable de seguridad (`aragon.es/security-owner`).
+
+## Consecuencias
+
+- El catalogo distingue propietario tecnico y responsable de seguridad.
+- Las plantillas generan metadatos de gobernanza completos por defecto.
+- La memoria debe justificar por que no se consume la anotacion con un plugin.
+- Una extension natural seria un plugin de alertas para componentes sin security-owner.

--- a/docs/adr/0009-distincion-ou-security-group.md
+++ b/docs/adr/0009-distincion-ou-security-group.md
@@ -1,0 +1,34 @@
+# ADR-0009: Distinción Unidad Organizativa (OU) vs. Grupo de Seguridad Como Principio Rector
+
+## Estado
+
+Aceptada
+
+## Contexto
+
+ADR-0001 a ADR-0008 ya separan, en la práctica, dos tipos de nodo en el catálogo: los 4 `team` sincronizados desde Keycloak (`equipo-frontend`, `equipo-spring`, `platform-admins`, `security-reviewers`) y los 8 nodos estáticos de la jerarquía AST (`ast`, business-units, product-areas). `permission-policy.ts` solo mapea los 4 `team` a roles; los nodos estáticos no otorgan ningún permiso.
+
+Sin embargo, ningún ADR anterior explicita *por qué* esta separación es correcta, ni la conecta con un principio reconocible fuera del prototipo. Esto deja la decisión sin defensa citable: ante la pregunta "¿por qué la jerarquía AST no vive en Keycloak, si en una AAPP los grupos están centralizados en el directorio?", la respuesta implícita hasta ahora ("Keycloak solo modela grupos planos") es circular, porque el propio autor del TFG diseñó el realm de Keycloak.
+
+En un Active Directory (o equivalente), existen dos primitivas distintas que se confunden coloquialmente bajo "grupo":
+
+- **Security groups**: otorgan acceso. Los usuarios son miembros; se referencian directamente en políticas de autorización.
+- **Organizational Units (OUs)**: estructura administrativa (el organigrama). Los objetos viven dentro, pero la pertenencia a una OU no otorga acceso a aplicaciones — usar OUs para autorizar produce herencia de permisos no deseada en cascada.
+
+## Decisión
+
+Adoptar la distinción OU / security-group como principio rector, ya materializado por la implementación existente:
+
+- Los 4 `team` (`equipo-frontend`, `equipo-spring`, `platform-admins`, `security-reviewers`) son **security groups**: fuente de acceso, centralizados en Keycloak, consumidos por `permission-policy.ts`.
+- Los 8 nodos estáticos de `catalog/seed/org-ast.yaml` (`ast`, business-units, product-areas) son **unidades organizativas (OUs)**: estructura de gobierno, sin permisos propios, materializadas como YAML de catálogo en el prototipo.
+
+La justificación para no reflejar las OUs en Keycloak no es una limitación técnica de Keycloak, sino un principio de diseño: en un AD real las OUs tampoco se modelan como security groups anidados, porque los grupos anidados en Keycloak (y en AD) heredan role-mappings del padre — usar esa primitiva para modelar estructura administrativa sería el antipatrón inverso al que se busca evitar.
+
+Se documenta explícitamente que, en un despliegue real, el organigrama también podría vivir en el directorio corporativo como OUs (el plugin `catalog-backend-module-keycloak` ya soporta `subGroups → children`, mismo mecanismo que `spec.children`); se ha optado por YAML de catálogo en el prototipo por ser una decisión de demostración, no una limitación.
+
+## Consecuencias
+
+- Sustituye la justificación implícita "Keycloak solo modela grupos planos" (nunca escrita como tal en los ADR anteriores, pero presente como razonamiento informal) por un principio citable y defendible.
+- ADR-0003 queda marcado como superseded por ADR-0005; ambos son coherentes con este principio.
+- La memoria puede citar este ADR para responder a la pregunta "¿por qué los permisos vienen de Keycloak y no del catálogo?" y "¿por qué la jerarquía AST no está en el directorio?".
+- Si en el futuro se decide migrar la jerarquía AST al directorio como OUs, la migración es técnicamente trivial (mecanismo ya verificado) y no invalida este ADR: solo cambia dónde se almacena la misma distinción conceptual.

--- a/docs/keycloack/catalog-sync-flow-visual.md
+++ b/docs/keycloack/catalog-sync-flow-visual.md
@@ -47,7 +47,7 @@ KEYCLOAK (aragon-idp)
 |-- USUARIOS HUMANOS
 |   |
 |   |-- jperez
-|   |   |-- groups: ["/developers"]
+|   |   |-- groups: ["/equipo-frontend"]
 |   |   +-- realmRoles: ["default-roles-aragon-idp"]
 |   |
 |   |-- agarcia
@@ -58,13 +58,22 @@ KEYCLOAK (aragon-idp)
 |   |   |-- groups: ["/security-reviewers"]
 |   |   +-- realmRoles: ["default-roles-aragon-idp"]
 |   |
-|   +-- mgarcia
-|       |-- groups: ["/developers", "/security-reviewers"]
+|   |-- mgarcia
+|   |   |-- groups: ["/equipo-frontend", "/security-reviewers"]
+|   |   +-- realmRoles: ["default-roles-aragon-idp"]
+|   |
+|   |-- lruiz
+|   |   |-- groups: ["/equipo-spring"]
+|   |   +-- realmRoles: ["default-roles-aragon-idp"]
+|   |
+|   +-- jgomez
+|       |-- groups: ["/equipo-spring"]
 |       +-- realmRoles: ["default-roles-aragon-idp"]
 |
 |-- GRUPOS
 |   |
-|   |-- developers
+|   |-- equipo-frontend
+|   |-- equipo-spring
 |   |-- platform-admins
 |   +-- security-reviewers
 |
@@ -223,7 +232,8 @@ BACKSTAGE
        |                                     |
        |<------------------------------------|
        |  "Aqui tienes la lista:"            |
-       |  [jperez, agarcia, msanchez, ...]   |
+       |  [jperez, agarcia, msanchez,        |
+       |   mgarcia, lruiz, jgomez, ...]      |
        |                                     |
 ```
 
@@ -243,7 +253,7 @@ Authorization: Bearer <token>
     "lastName": "Perez",
     "email": "jperez@aragon.es",
     "enabled": true,
-    "groups": ["/developers"]
+    "groups": ["/equipo-frontend"]
   },
   {
     "id": "5d758e24-...",
@@ -253,6 +263,15 @@ Authorization: Bearer <token>
     "email": "agarcia@aragon.es",
     "enabled": true,
     "groups": ["/platform-admins"]
+  },
+  {
+    "id": "407d8364-...",
+    "username": "lruiz",
+    "firstName": "Laura",
+    "lastName": "Ruiz",
+    "email": "lruiz@aragon.es",
+    "enabled": true,
+    "groups": ["/equipo-spring"]
   }
 ]
 ```
@@ -286,7 +305,8 @@ Authorization: Bearer <token>
        |                                     |
        |<------------------------------------|
        |  "Aqui tienes la lista:"            |
-       |  [developers, platform-admins, ...] |
+       |  [equipo-frontend, equipo-spring,   |
+       |   platform-admins, ...]             |
        |                                     |
 ```
 
@@ -301,8 +321,13 @@ Authorization: Bearer <token>
 [
   {
     "id": "90b0913c-...",
-    "name": "developers",
-    "path": "/developers"
+    "name": "equipo-frontend",
+    "path": "/equipo-frontend"
+  },
+  {
+    "id": "db9c171f-...",
+    "name": "equipo-spring",
+    "path": "/equipo-spring"
   },
   {
     "id": "2ac126ad-...",
@@ -339,7 +364,7 @@ Authorization: Bearer <token>
 |    email: "jperez@aragon.es"                              |
 |    firstName: "Juan"                                      |
 |    lastName: "Perez"                                      |
-|    groups: ["/developers"]                                |
+|    groups: ["/equipo-frontend"]                           |
 |       |                                                   |
 |       v                                                   |
 |  +--------------------------------------------------+     |
@@ -353,21 +378,21 @@ Authorization: Bearer <token>
 |  |    profile:                                      |     |
 |  |      displayName: Juan Perez                     |     |
 |  |      email: jperez@aragon.es                     |     |
-|  |    memberOf: [group:default/developers]          |     |
+|  |    memberOf: [group:default/equipo-frontend]    |     |
 |  +--------------------------------------------------+     |
 |                                                           |
-|  Grupo developers                                         |
-|    name: "developers"                                     |
-|    path: "/developers"                                    |
+|  Grupo equipo-frontend                                    |
+|    name: "equipo-frontend"                                |
+|    path: "/equipo-frontend"                               |
 |       |                                                   |
 |       v                                                   |
 |  +--------------------------------------------------+     |
-|  |  ENTIDAD: Group:default/developers               |     |
+|  |  ENTIDAD: Group:default/equipo-frontend          |     |
 |  |                                                  |     |
 |  |  apiVersion: backstage.io/v1alpha1               |     |
 |  |  kind: Group                                     |     |
 |  |  metadata:                                       |     |
-|  |    name: developers                              |     |
+|  |    name: equipo-frontend                         |     |
 |  |  spec:                                           |     |
 |  |    type: team                                    |     |
 |  |    children: []                                  |     |
@@ -403,8 +428,13 @@ Authorization: Bearer <token>
        |  - User:default/jperez              |
        |  - User:default/agarcia             |
        |  - User:default/msanchez            |
-       |  - Group:default/developers         |
+       |  - User:default/mgarcia             |
+       |  - User:default/lruiz               |
+       |  - User:default/jgomez              |
+       |  - Group:default/equipo-frontend    |
+       |  - Group:default/equipo-spring      |
        |  - Group:default/platform-admins    |
+       |  - Group:default/security-reviewers |
        |------------------------------------>|
        |                                     |
        |<------------------------------------|
@@ -420,7 +450,7 @@ CATALOGO DE BACKSTAGE (SQLite)
 |-- User:default/jperez
 |   |-- spec.profile.displayName: "Juan Perez"
 |   |-- spec.profile.email: "jperez@aragon.es"
-|   +-- spec.memberOf: ["group:default/developers"]
+|   +-- spec.memberOf: ["group:default/equipo-frontend"]
 |
 |-- User:default/agarcia
 |   |-- spec.profile.displayName: "Ana Garcia"
@@ -435,10 +465,23 @@ CATALOGO DE BACKSTAGE (SQLite)
 |-- User:default/mgarcia
 |   |-- spec.profile.displayName: "Manuel Garcia"
 |   |-- spec.profile.email: "mgarcia@aragon.es"
-|   +-- spec.memberOf: ["group:default/developers",
-|                        "group:default/security-reviewers"]
+|   +-- spec.memberOf: ["group:default/equipo-frontend",
+|                       "group:default/security-reviewers"]
 |
-|-- Group:default/developers
+|-- User:default/lruiz
+|   |-- spec.profile.displayName: "Laura Ruiz"
+|   |-- spec.profile.email: "lruiz@aragon.es"
+|   +-- spec.memberOf: ["group:default/equipo-spring"]
+|
+|-- User:default/jgomez
+|   |-- spec.profile.displayName: "Javier Gomez"
+|   |-- spec.profile.email: "jgomez@aragon.es"
+|   +-- spec.memberOf: ["group:default/equipo-spring"]
+|
+|-- Group:default/equipo-frontend
+|   +-- spec.type: "team"
+|
+|-- Group:default/equipo-spring
 |   +-- spec.type: "team"
 |
 |-- Group:default/platform-admins
@@ -450,7 +493,7 @@ CATALOGO DE BACKSTAGE (SQLite)
 
 > **Entidades:**
 > - **Catalogo:** Ahora contiene entidades `User` y `Group` sincronizadas
-> - **Relaciones:** `jperez` pertenece a `developers`, `agarcia` a `platform-admins`, etc.
+> - **Relaciones:** `jperez` pertenece a `equipo-frontend`, `agarcia` a `platform-admins`, `lruiz` y `jgomez` a `equipo-spring`, etc.
 
 > **Memoria:** El catalogo es la agenda de contactos de Backstage. Ahora tiene copiados todos los empleados y departamentos de RRHH.
 
@@ -470,7 +513,7 @@ CATALOGO DE BACKSTAGE (SQLite)
 |  |  signInResolver busca: User:default/jperez       |     |
 |  |  -> ENCONTRADO                                   |     |
 |  |  -> Juan puede entrar                            |     |
-|  |  -> Se sabe que es del grupo developers          |     |
+|  |  -> Se sabe que es del grupo equipo-frontend     |     |
 |  |                                                  |     |
 |  |  Si no estuviera sincronizado:                   |     |
 |  |  -> User:default/jperez NO EXISTE                |     |
@@ -555,7 +598,9 @@ CATALOGO DE BACKSTAGE (SQLite)
   |-----------------------> |
   |  KEYCLOAK               |
   |  "Aqui: jperez,        |
-  |   agarcia, msanchez..." |
+  |   agarcia, msanchez,   |
+  |   mgarcia, lruiz,      |
+  |   jgomez..."           |
   |<----------------------- |
   |                         |
   |  4. "Dame grupos"       |
@@ -563,8 +608,10 @@ CATALOGO DE BACKSTAGE (SQLite)
   |      al robot]          |
   |-----------------------> |
   |  KEYCLOAK               |
-  |  "Aqui: developers,     |
-  |   platform-admins..."   |
+  |  "Aqui: equipo-        |
+  |   frontend, equipo-    |
+  |   spring, platform-    |
+  |   admins..."           |
   |<----------------------- |
   +-------------------------+
      |
@@ -578,6 +625,8 @@ CATALOGO DE BACKSTAGE (SQLite)
   |  6. Registra/Actualiza: |
   |     User:default/jperez |
   |     User:default/agarcia|
+  |     User:default/lruiz  |
+  |     User:default/jgomez |
   |     Group:default/...   |
   |                         |
   |  7. Listo para login    |

--- a/examples/templates/backend-spring-boot/content/CODEOWNERS
+++ b/examples/templates/backend-spring-boot/content/CODEOWNERS
@@ -10,4 +10,4 @@ src/main/resources/        @security-reviewers
 /catalog-info.yaml         @security-reviewers
 
 # Resto del repositorio
-*                          @platform-admin
+*                          @equipo-spring

--- a/examples/templates/backend-spring-boot/content/catalog-info.yaml
+++ b/examples/templates/backend-spring-boot/content/catalog-info.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     aragon.es/nivel-ens: ${{ values.nivel_ens }}
     aragon.es/skeleton-version: ${{ values.skeletonVersion }}
+    aragon.es/security-owner: group:default/security-reviewers
     backstage.io/techdocs-ref: dir:.
 spec:
   type: service

--- a/examples/templates/backend-spring-boot/template.yaml
+++ b/examples/templates/backend-spring-boot/template.yaml
@@ -11,7 +11,7 @@ metadata:
     - golden-path
 spec:
   type: service
-  owner: platform-team
+  owner: group:default/equipo-spring
 
   parameters:
     - title: Información del servicio
@@ -33,6 +33,7 @@ spec:
           type: string
           description: Grupo responsable del servicio (solo tus grupos)
           ui:field: MyGroupsPicker
+          default: group:default/equipo-spring
         system:
           title: Sistema
           type: string

--- a/examples/templates/frontend-angular-desy/content/CODEOWNERS
+++ b/examples/templates/frontend-angular-desy/content/CODEOWNERS
@@ -9,4 +9,4 @@ src/environments/        @security-reviewers
 /catalog-info.yaml       @security-reviewers
 
 # Resto del repositorio
-*                        @platform-admin
+*                        @equipo-frontend

--- a/examples/templates/frontend-angular-desy/content/catalog-info.yaml
+++ b/examples/templates/frontend-angular-desy/content/catalog-info.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     aragon.es/nivel-ens: ${{ values.nivel_ens }}
     aragon.es/skeleton-version: ${{ values.skeletonVersion }}
+    aragon.es/security-owner: group:default/security-reviewers
     backstage.io/techdocs-ref: dir:.
   tags:
     - desy

--- a/examples/templates/frontend-angular-desy/template.yaml
+++ b/examples/templates/frontend-angular-desy/template.yaml
@@ -14,7 +14,7 @@ metadata:
     - frontend
     - angular
 spec:
-  owner: group:default/platform-admin
+  owner: group:default/equipo-frontend
   type: website
 
   parameters:
@@ -43,6 +43,7 @@ spec:
           type: string
           description: Grupo responsable del componente (solo tus grupos)
           ui:field: MyGroupsPicker
+          default: group:default/equipo-frontend
         system:
           title: Sistema
           type: string

--- a/keycloak/realm-export/aragon-idp-realm.json
+++ b/keycloak/realm-export/aragon-idp-realm.json
@@ -110,8 +110,17 @@
   "groups": [
     {
       "id": "90b0913c-1c9b-4b30-bcf1-9ee1fad0fb08",
-      "name": "developers",
-      "path": "/developers",
+      "name": "equipo-frontend",
+      "path": "/equipo-frontend",
+      "attributes": {},
+      "realmRoles": [],
+      "clientRoles": {},
+      "subGroups": []
+    },
+    {
+      "id": "db9c171f-2a74-4ffe-b712-424b9d934447",
+      "name": "equipo-spring",
+      "path": "/equipo-spring",
       "attributes": {},
       "realmRoles": [],
       "clientRoles": {},
@@ -152,7 +161,7 @@
           "temporary": false
         }
       ],
-      "groups": ["/developers"],
+      "groups": ["/equipo-frontend"],
       "realmRoles": [
         "default-roles-aragon-idp",
         "offline_access",
@@ -218,7 +227,51 @@
           "temporary": false
         }
       ],
-      "groups": ["/developers", "/security-reviewers"],
+      "groups": ["/equipo-frontend", "/security-reviewers"],
+      "realmRoles": [
+        "default-roles-aragon-idp",
+        "offline_access",
+        "uma_authorization"
+      ]
+    },
+    {
+      "id": "407d8364-45e3-4a0a-9831-02bbd70e839d",
+      "username": "lruiz",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Laura",
+      "lastName": "Ruiz",
+      "email": "lruiz@aragon.es",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "changeme",
+          "temporary": false
+        }
+      ],
+      "groups": ["/equipo-spring"],
+      "realmRoles": [
+        "default-roles-aragon-idp",
+        "offline_access",
+        "uma_authorization"
+      ]
+    },
+    {
+      "id": "6efe843d-5fc7-439b-9a4d-59903928fa71",
+      "username": "jgomez",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Javier",
+      "lastName": "Gomez",
+      "email": "jgomez@aragon.es",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "changeme",
+          "temporary": false
+        }
+      ],
+      "groups": ["/equipo-spring"],
       "realmRoles": [
         "default-roles-aragon-idp",
         "offline_access",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -58,7 +58,8 @@
     "pg": "^8.11.3"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.35.4"
+    "@backstage/cli": "^0.35.4",
+    "yaml": "^2.8.2"
   },
   "files": [
     "dist"

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -11,6 +11,7 @@ import {
   auditStoreServiceFactory,
   auditorServiceFactory,
 } from '@internal/backstage-plugin-audit-backend';
+import { keycloakGroupTransformerModule } from './modules/keycloakGroupTransformer';
 import { oidcAuthProviderModule } from './modules/oidcAuthProvider';
 import { tfgCatalogValidatorModule } from './modules/tfgCatalogValidator';
 import { permissionPolicyModule } from './permission-policy';
@@ -82,6 +83,7 @@ backend.add(import('@backstage/plugin-signals-backend'));
 backend.add(
   import('@backstage-community/plugin-catalog-backend-module-keycloak'),
 );
+backend.add(keycloakGroupTransformerModule);
 
 // audit-log plugin (issue #65)
 // - audit-backend mounts GET /api/audit/events

--- a/packages/backend/src/modules/keycloakGroupTransformer.test.ts
+++ b/packages/backend/src/modules/keycloakGroupTransformer.test.ts
@@ -1,0 +1,46 @@
+import { customGroupTransformer } from './keycloakGroupTransformer';
+
+function makeEntity(name: string, overrides?: Record<string, unknown>): any {
+  return {
+    apiVersion: 'backstage.io/v1beta1',
+    kind: 'Group',
+    metadata: { name },
+    spec: { type: 'group', children: [], members: [], profile: { displayName: name } },
+    ...overrides,
+  };
+}
+
+describe('customGroupTransformer', () => {
+  it('sets spec.type to "team"', async () => {
+    const entity = makeEntity('equipo-frontend');
+
+    const result = await customGroupTransformer(entity, {} as any, 'aragon-idp');
+
+    expect(result?.spec?.type).toBe('team');
+  });
+
+  it('preserves metadata and other spec fields unchanged', async () => {
+    const entity = makeEntity('equipo-spring');
+
+    const result = await customGroupTransformer(entity, {} as any, 'aragon-idp');
+
+    expect(result?.metadata.name).toBe('equipo-spring');
+    expect(result?.spec.children).toEqual([]);
+    expect(result?.spec.profile.displayName).toBe('equipo-spring');
+  });
+
+  it('works for all four teams', async () => {
+    const teams = [
+      'equipo-frontend',
+      'equipo-spring',
+      'platform-admins',
+      'security-reviewers',
+    ];
+
+    for (const name of teams) {
+      const entity = makeEntity(name);
+      const result = await customGroupTransformer(entity, {} as any, 'aragon-idp');
+      expect(result?.spec?.type).toBe('team');
+    }
+  });
+});

--- a/packages/backend/src/modules/keycloakGroupTransformer.test.ts
+++ b/packages/backend/src/modules/keycloakGroupTransformer.test.ts
@@ -5,7 +5,12 @@ function makeEntity(name: string, overrides?: Record<string, unknown>): any {
     apiVersion: 'backstage.io/v1beta1',
     kind: 'Group',
     metadata: { name },
-    spec: { type: 'group', children: [], members: [], profile: { displayName: name } },
+    spec: {
+      type: 'group',
+      children: [],
+      members: [],
+      profile: { displayName: name },
+    },
     ...overrides,
   };
 }
@@ -14,7 +19,11 @@ describe('customGroupTransformer', () => {
   it('sets spec.type to "team"', async () => {
     const entity = makeEntity('equipo-frontend');
 
-    const result = await customGroupTransformer(entity, {} as any, 'aragon-idp');
+    const result = await customGroupTransformer(
+      entity,
+      {} as any,
+      'aragon-idp',
+    );
 
     expect(result?.spec?.type).toBe('team');
   });
@@ -22,11 +31,15 @@ describe('customGroupTransformer', () => {
   it('preserves metadata and other spec fields unchanged', async () => {
     const entity = makeEntity('equipo-spring');
 
-    const result = await customGroupTransformer(entity, {} as any, 'aragon-idp');
+    const result = await customGroupTransformer(
+      entity,
+      {} as any,
+      'aragon-idp',
+    );
 
     expect(result?.metadata.name).toBe('equipo-spring');
     expect(result?.spec.children).toEqual([]);
-    expect(result?.spec.profile.displayName).toBe('equipo-spring');
+    expect(result?.spec.profile?.displayName).toBe('equipo-spring');
   });
 
   it('works for all four teams', async () => {
@@ -39,7 +52,11 @@ describe('customGroupTransformer', () => {
 
     for (const name of teams) {
       const entity = makeEntity(name);
-      const result = await customGroupTransformer(entity, {} as any, 'aragon-idp');
+      const result = await customGroupTransformer(
+        entity,
+        {} as any,
+        'aragon-idp',
+      );
       expect(result?.spec?.type).toBe('team');
     }
   });

--- a/packages/backend/src/modules/keycloakGroupTransformer.ts
+++ b/packages/backend/src/modules/keycloakGroupTransformer.ts
@@ -4,7 +4,11 @@ import {
   keycloakTransformerExtensionPoint,
 } from '@backstage-community/plugin-catalog-backend-module-keycloak';
 
-export const customGroupTransformer: GroupTransformer = async (entity, _group, _realm) => {
+export const customGroupTransformer: GroupTransformer = async (
+  entity,
+  _group,
+  _realm,
+) => {
   return { ...entity, spec: { ...entity.spec, type: 'team' } };
 };
 

--- a/packages/backend/src/modules/keycloakGroupTransformer.ts
+++ b/packages/backend/src/modules/keycloakGroupTransformer.ts
@@ -1,0 +1,24 @@
+import { createBackendModule } from '@backstage/backend-plugin-api';
+import {
+  GroupTransformer,
+  keycloakTransformerExtensionPoint,
+} from '@backstage-community/plugin-catalog-backend-module-keycloak';
+
+export const customGroupTransformer: GroupTransformer = async (entity, _group, _realm) => {
+  return { ...entity, spec: { ...entity.spec, type: 'team' } };
+};
+
+export const keycloakGroupTransformerModule = createBackendModule({
+  pluginId: 'catalog',
+  moduleId: 'keycloak-group-type',
+  register(reg) {
+    reg.registerInit({
+      deps: {
+        keycloak: keycloakTransformerExtensionPoint,
+      },
+      async init({ keycloak }) {
+        keycloak.setGroupTransformer(customGroupTransformer);
+      },
+    });
+  },
+});

--- a/packages/backend/src/orgAstCatalog.test.ts
+++ b/packages/backend/src/orgAstCatalog.test.ts
@@ -1,0 +1,113 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { parseAllDocuments } from 'yaml';
+import { groupEntityV1alpha1Validator } from '@backstage/catalog-model';
+
+// The static file under test. Resolved from `packages/backend/src` (3 levels
+// up = repo root) so it does not depend on Jest's cwd.
+const ORG_AST_PATH = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'catalog',
+  'seed',
+  'org-ast.yaml',
+);
+
+type GroupEntity = {
+  apiVersion: string;
+  kind: string;
+  metadata: { name: string };
+  spec: { type: string; children?: string[]; members?: unknown[] };
+};
+
+function loadGroups(): GroupEntity[] {
+  const text = readFileSync(ORG_AST_PATH, 'utf8');
+  const docs = parseAllDocuments(text);
+  return docs.map(d => d.toJS() as GroupEntity);
+}
+
+describe('catalog/seed/org-ast.yaml — AST 4-level hierarchy', () => {
+  const groups = loadGroups();
+  const byName = new Map(groups.map(g => [g.metadata.name, g]));
+
+  it('parses as 8 valid Group entities against the Group.v1alpha1 schema', async () => {
+    expect(groups).toHaveLength(8);
+    for (const g of groups) {
+      expect(g.kind).toBe('Group');
+      const entity = {
+        apiVersion: g.apiVersion,
+        kind: g.kind,
+        metadata: { name: g.metadata.name },
+        spec: { type: g.spec.type, children: g.spec.children ?? [] },
+      };
+      await expect(
+        groupEntityV1alpha1Validator.check(entity),
+      ).resolves.toBeTruthy();
+    }
+  });
+
+  it('defines exactly the 8 expected static groups', () => {
+    expect(groups.map(g => g.metadata.name).sort()).toEqual(
+      [
+        'ast',
+        'desarrollo',
+        'desarrollo-backend',
+        'desarrollo-web',
+        'gobierno-datos',
+        'plataforma',
+        'seguridad',
+        'sre',
+      ].sort(),
+    );
+  });
+
+  it('assigns the governance vocabulary to spec.type (ADR-0005)', () => {
+    expect(byName.get('ast')?.spec.type).toBe('organization');
+    for (const bu of ['desarrollo', 'plataforma', 'seguridad']) {
+      expect(byName.get(bu)?.spec.type).toBe('business-unit');
+    }
+    for (const pa of [
+      'desarrollo-web',
+      'desarrollo-backend',
+      'sre',
+      'gobierno-datos',
+    ]) {
+      expect(byName.get(pa)?.spec.type).toBe('product-area');
+    }
+  });
+
+  it('does not declare spec.members on any static node (ADR-0004)', () => {
+    for (const g of groups) {
+      expect(g.spec.members).toBeUndefined();
+    }
+  });
+
+  it('wires the hierarchy via spec.children', () => {
+    expect(byName.get('ast')?.spec.children).toEqual([
+      'desarrollo',
+      'plataforma',
+      'seguridad',
+    ]);
+    expect(byName.get('desarrollo')?.spec.children).toEqual([
+      'desarrollo-web',
+      'desarrollo-backend',
+    ]);
+    expect(byName.get('plataforma')?.spec.children).toEqual(['sre']);
+    expect(byName.get('seguridad')?.spec.children).toEqual(['gobierno-datos']);
+  });
+
+  it('product-areas point at the real teams (which come from Keycloak)', () => {
+    expect(byName.get('desarrollo-web')?.spec.children).toEqual([
+      'equipo-frontend',
+    ]);
+    expect(byName.get('desarrollo-backend')?.spec.children).toEqual([
+      'equipo-spring',
+    ]);
+    expect(byName.get('sre')?.spec.children).toEqual(['platform-admins']);
+    expect(byName.get('gobierno-datos')?.spec.children).toEqual([
+      'security-reviewers',
+    ]);
+  });
+});

--- a/packages/backend/src/permission-policy.test.ts
+++ b/packages/backend/src/permission-policy.test.ts
@@ -42,10 +42,28 @@ function makeUser(refs: string[]): PolicyQueryUser {
 }
 
 describe('extractRoles', () => {
-  it('extracts developer from group:default/developers', () => {
-    expect(extractRoles(makeUser(['group:default/developers']))).toEqual([
+  it('extracts developer from group:default/equipo-frontend', () => {
+    expect(extractRoles(makeUser(['group:default/equipo-frontend']))).toEqual([
       'developer',
     ]);
+  });
+
+  it('extracts developer from group:default/equipo-spring', () => {
+    expect(extractRoles(makeUser(['group:default/equipo-spring']))).toEqual([
+      'developer',
+    ]);
+  });
+
+  it('maps unprefixed equipo-frontend to developer', () => {
+    expect(extractRoles(makeUser(['equipo-frontend']))).toEqual(['developer']);
+  });
+
+  it('maps unprefixed equipo-spring to developer', () => {
+    expect(extractRoles(makeUser(['equipo-spring']))).toEqual(['developer']);
+  });
+
+  it('does not map the renamed group:default/developers to any role', () => {
+    expect(extractRoles(makeUser(['group:default/developers']))).toEqual([]);
   });
 
   it('extracts platform-admin from group:default/platform-admins', () => {
@@ -83,6 +101,18 @@ describe('extractRoles', () => {
     expect(roles).toContain('security-reviewer');
     expect(roles).toHaveLength(2);
   });
+
+  it('returns union of developer + security-reviewer for equipo-frontend + security-reviewers (OR semantics)', () => {
+    const roles = extractRoles(
+      makeUser([
+        'group:default/equipo-frontend',
+        'group:default/security-reviewers',
+      ]),
+    );
+    expect(roles).toContain('developer');
+    expect(roles).toContain('security-reviewer');
+    expect(roles).toHaveLength(2);
+  });
 });
 
 describe('AragonPermissionPolicy', () => {
@@ -98,7 +128,7 @@ describe('AragonPermissionPolicy', () => {
   describe('Catalog permissions', () => {
     it('allows all roles to read catalog entities', async () => {
       for (const user of [
-        makeUser(['group:default/developers']),
+        makeUser(['group:default/equipo-frontend']),
         makeUser(['group:default/platform-admins']),
         makeUser(['group:default/security-reviewers']),
       ]) {
@@ -121,7 +151,7 @@ describe('AragonPermissionPolicy', () => {
     it('allows developer to create location (from scaffolder)', async () => {
       const result = await policy.handle(
         makeQuery('catalog.location.create'),
-        makeUser(['group:default/developers']),
+        makeUser(['group:default/equipo-frontend']),
       );
       expect(result.result).toBe(AuthorizeResult.ALLOW);
     });
@@ -129,7 +159,7 @@ describe('AragonPermissionPolicy', () => {
     it('allows developer to create catalog entity (from scaffolder)', async () => {
       const result = await policy.handle(
         makeQuery('catalog.entity.create'),
-        makeUser(['group:default/developers']),
+        makeUser(['group:default/equipo-frontend']),
       );
       expect(result.result).toBe(AuthorizeResult.ALLOW);
     });
@@ -137,7 +167,7 @@ describe('AragonPermissionPolicy', () => {
     it('denies developer from deleting catalog entity', async () => {
       const result = await policy.handle(
         makeQuery('catalog.entity.delete'),
-        makeUser(['group:default/developers']),
+        makeUser(['group:default/equipo-frontend']),
       );
       expect(result.result).toBe(AuthorizeResult.DENY);
     });
@@ -147,7 +177,7 @@ describe('AragonPermissionPolicy', () => {
     it('allows developer to execute template', async () => {
       const result = await policy.handle(
         makeQuery('scaffolder.task.create'),
-        makeUser(['group:default/developers']),
+        makeUser(['group:default/equipo-frontend']),
       );
       expect(result.result).toBe(AuthorizeResult.ALLOW);
     });
@@ -155,7 +185,7 @@ describe('AragonPermissionPolicy', () => {
     it('allows developer to read template steps', async () => {
       const result = await policy.handle(
         makeQuery('scaffolder.template.step.read'),
-        makeUser(['group:default/developers']),
+        makeUser(['group:default/equipo-frontend']),
       );
       expect(result.result).toBe(AuthorizeResult.ALLOW);
     });
@@ -171,7 +201,7 @@ describe('AragonPermissionPolicy', () => {
     it('allows developer to read task logs', async () => {
       const result = await policy.handle(
         makeQuery('scaffolder.task.read'),
-        makeUser(['group:default/developers']),
+        makeUser(['group:default/equipo-frontend']),
       );
       expect(result.result).toBe(AuthorizeResult.ALLOW);
     });
@@ -223,6 +253,28 @@ describe('AragonPermissionPolicy', () => {
       );
       expect(result.result).toBe(AuthorizeResult.ALLOW);
     });
+
+    it('allows equipo-frontend + security-reviewer to execute developer actions (OR semantics)', async () => {
+      const result = await policy.handle(
+        makeQuery('scaffolder.task.create'),
+        makeUser([
+          'group:default/equipo-frontend',
+          'group:default/security-reviewers',
+        ]),
+      );
+      expect(result.result).toBe(AuthorizeResult.ALLOW);
+    });
+
+    it('allows equipo-frontend + security-reviewer to read audit events (OR semantics)', async () => {
+      const result = await policy.handle(
+        makeQuery('audit.event.read'),
+        makeUser([
+          'group:default/equipo-frontend',
+          'group:default/security-reviewers',
+        ]),
+      );
+      expect(result.result).toBe(AuthorizeResult.ALLOW);
+    });
   });
 
   describe('Audit permissions', () => {
@@ -245,7 +297,7 @@ describe('AragonPermissionPolicy', () => {
     it('denies developer from reading audit events', async () => {
       const result = await policy.handle(
         makeQuery('audit.event.read'),
-        makeUser(['group:default/developers']),
+        makeUser(['group:default/equipo-frontend']),
       );
       expect(result.result).toBe(AuthorizeResult.DENY);
     });
@@ -290,7 +342,7 @@ describe('AragonPermissionPolicy', () => {
     it('emits permission-decision with reason "unknown-permission" when permission is not in the matrix', async () => {
       await policy.handle(
         makeQuery('some.unknown.permission'),
-        makeUser(['group:default/developers']),
+        makeUser(['group:default/equipo-frontend']),
       );
 
       expect(auditor.createEvent).toHaveBeenCalledWith(
@@ -309,7 +361,7 @@ describe('AragonPermissionPolicy', () => {
     it('emits permission-decision with reason "no-matching-role" when user role does not match', async () => {
       await policy.handle(
         makeQuery('catalog.entity.delete'),
-        makeUser(['group:default/developers']),
+        makeUser(['group:default/equipo-frontend']),
       );
 
       expect(auditor.createEvent).toHaveBeenCalledWith(
@@ -328,7 +380,7 @@ describe('AragonPermissionPolicy', () => {
     it('does NOT emit on ALLOW', async () => {
       await policy.handle(
         makeQuery('catalog.entity.read'),
-        makeUser(['group:default/developers']),
+        makeUser(['group:default/equipo-frontend']),
       );
 
       expect(auditor.createEvent).not.toHaveBeenCalled();
@@ -341,7 +393,7 @@ describe('AragonPermissionPolicy', () => {
     it('denies unlisted permissions', async () => {
       const result = await policy.handle(
         makeQuery('some.unknown.permission'),
-        makeUser(['group:default/developers']),
+        makeUser(['group:default/equipo-frontend']),
       );
       expect(result.result).toBe(AuthorizeResult.DENY);
     });

--- a/packages/backend/src/permission-policy.ts
+++ b/packages/backend/src/permission-policy.ts
@@ -17,10 +17,12 @@ import { AuditorService, LoggerService } from '@backstage/backend-plugin-api';
 type Role = 'developer' | 'platform-admin' | 'security-reviewer';
 
 const GROUP_TO_ROLE: Record<string, Role> = {
-  'group:default/developers': 'developer',
+  'group:default/equipo-frontend': 'developer',
+  'group:default/equipo-spring': 'developer',
   'group:default/platform-admins': 'platform-admin',
   'group:default/security-reviewers': 'security-reviewer',
-  developers: 'developer',
+  'equipo-frontend': 'developer',
+  'equipo-spring': 'developer',
   'platform-admins': 'platform-admin',
   'security-reviewers': 'security-reviewer',
 };

--- a/packages/backend/src/scaffolderTemplates.test.ts
+++ b/packages/backend/src/scaffolderTemplates.test.ts
@@ -55,7 +55,10 @@ const SECURITY_OWNER = 'group:default/security-reviewers';
 describe('examples/templates — golden-path owners, security-owner, CODEOWNERS', () => {
   describe('backend-spring-boot', () => {
     const manifest = loadManifest('backend-spring-boot');
-    const catalogInfo = readFile('backend-spring-boot', 'content/catalog-info.yaml');
+    const catalogInfo = readFile(
+      'backend-spring-boot',
+      'content/catalog-info.yaml',
+    );
     const codeowners = readFile('backend-spring-boot', 'content/CODEOWNERS');
 
     it('template spec.owner is equipo-spring (team custodian of the golden path)', () => {
@@ -63,7 +66,9 @@ describe('examples/templates — golden-path owners, security-owner, CODEOWNERS'
     });
 
     it('owner parameter defaults to equipo-spring', () => {
-      expect(findOwnerPicker(manifest).default).toBe('group:default/equipo-spring');
+      expect(findOwnerPicker(manifest).default).toBe(
+        'group:default/equipo-spring',
+      );
     });
 
     it('catalog-info.yaml carries security-owner and keeps the ENS annotations', () => {

--- a/packages/backend/src/scaffolderTemplates.test.ts
+++ b/packages/backend/src/scaffolderTemplates.test.ts
@@ -1,0 +1,125 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { parseDocument } from 'yaml';
+
+// The templates under test. Resolved from `packages/backend/src` (3 levels
+// up = repo root) so it does not depend on Jest's cwd — same pattern as
+// orgAstCatalog.test.ts and seedSecurityOwner.test.ts.
+const TEMPLATES_DIR = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'examples',
+  'templates',
+);
+
+type OwnerParam = {
+  'ui:field'?: string;
+  default?: string;
+};
+
+type ParamStep = { properties: Record<string, OwnerParam> };
+
+type TemplateManifest = {
+  spec: { owner: string; parameters: ParamStep[] };
+};
+
+function loadManifest(template: string): TemplateManifest {
+  const text = readFileSync(
+    path.join(TEMPLATES_DIR, template, 'template.yaml'),
+    'utf8',
+  );
+  return parseDocument(text).toJS() as TemplateManifest;
+}
+
+function readFile(template: string, rel: string): string {
+  return readFileSync(path.join(TEMPLATES_DIR, template, rel), 'utf8');
+}
+
+// The owner parameter uses ui:field: MyGroupsPicker; its `default` is the
+// pre-selected team when the logged-in user is a member of it, so running a
+// template without customizing the owner assigns the component to that team.
+function findOwnerPicker(manifest: TemplateManifest): OwnerParam {
+  for (const step of manifest.spec.parameters) {
+    for (const key of Object.keys(step.properties)) {
+      const param = step.properties[key];
+      if (param['ui:field'] === 'MyGroupsPicker') return param;
+    }
+  }
+  throw new Error('No MyGroupsPicker parameter found in template manifest');
+}
+
+const SECURITY_OWNER = 'group:default/security-reviewers';
+
+describe('examples/templates — golden-path owners, security-owner, CODEOWNERS', () => {
+  describe('backend-spring-boot', () => {
+    const manifest = loadManifest('backend-spring-boot');
+    const catalogInfo = readFile('backend-spring-boot', 'content/catalog-info.yaml');
+    const codeowners = readFile('backend-spring-boot', 'content/CODEOWNERS');
+
+    it('template spec.owner is equipo-spring (team custodian of the golden path)', () => {
+      expect(manifest.spec.owner).toBe('group:default/equipo-spring');
+    });
+
+    it('owner parameter defaults to equipo-spring', () => {
+      expect(findOwnerPicker(manifest).default).toBe('group:default/equipo-spring');
+    });
+
+    it('catalog-info.yaml carries security-owner and keeps the ENS annotations', () => {
+      expect(catalogInfo).toContain(
+        `aragon.es/security-owner: ${SECURITY_OWNER}`,
+      );
+      expect(catalogInfo).toContain('aragon.es/nivel-ens:');
+      expect(catalogInfo).toContain('aragon.es/skeleton-version:');
+    });
+
+    it('CODEOWNERS points the rest of the repo at @equipo-spring and keeps @security-reviewers', () => {
+      expect(codeowners).toMatch(/^\*\s+@equipo-spring\s*$/m);
+      expect(codeowners).toContain('@security-reviewers');
+      expect(codeowners).not.toContain('@platform-admin');
+    });
+  });
+
+  describe('frontend-angular-desy', () => {
+    const manifest = loadManifest('frontend-angular-desy');
+    const catalogInfo = readFile(
+      'frontend-angular-desy',
+      'content/catalog-info.yaml',
+    );
+    const codeowners = readFile('frontend-angular-desy', 'content/CODEOWNERS');
+
+    it('template spec.owner is equipo-frontend (team custodian of the golden path)', () => {
+      expect(manifest.spec.owner).toBe('group:default/equipo-frontend');
+    });
+
+    it('owner parameter defaults to equipo-frontend', () => {
+      expect(findOwnerPicker(manifest).default).toBe(
+        'group:default/equipo-frontend',
+      );
+    });
+
+    it('catalog-info.yaml carries security-owner and keeps the ENS annotations', () => {
+      expect(catalogInfo).toContain(
+        `aragon.es/security-owner: ${SECURITY_OWNER}`,
+      );
+      expect(catalogInfo).toContain('aragon.es/nivel-ens:');
+      expect(catalogInfo).toContain('aragon.es/skeleton-version:');
+    });
+
+    it('CODEOWNERS points the rest of the repo at @equipo-frontend and keeps @security-reviewers', () => {
+      expect(codeowners).toMatch(/^\*\s+@equipo-frontend\s*$/m);
+      expect(codeowners).toContain('@security-reviewers');
+      expect(codeowners).not.toContain('@platform-admin');
+    });
+  });
+
+  describe('desy-project (example template, unchanged)', () => {
+    it('is not given a security-owner annotation and keeps its example owner', () => {
+      const manifest = loadManifest('desy-project');
+      const catalogInfo = readFile('desy-project', 'content/catalog-info.yaml');
+      expect(manifest.spec.owner).toBe('user:guest');
+      expect(catalogInfo).not.toContain('aragon.es/security-owner');
+    });
+  });
+});

--- a/packages/backend/src/seedSecurityOwner.test.ts
+++ b/packages/backend/src/seedSecurityOwner.test.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { parseAllDocuments } from 'yaml';
+import {
+  componentEntityV1alpha1Validator,
+  systemEntityV1alpha1Validator,
+} from '@backstage/catalog-model';
+
+// The two seed files under test. Resolved from `packages/backend/src` (3
+// levels up = repo root) so it does not depend on Jest's cwd — same pattern
+// as orgAstCatalog.test.ts.
+const SEED_DIR = path.resolve(__dirname, '..', '..', '..', 'catalog', 'seed');
+
+type Entity = {
+  apiVersion: string;
+  kind: string;
+  metadata: {
+    name: string;
+    annotations?: Record<string, string>;
+  };
+  spec: { owner: string };
+};
+
+function loadEntities(file: string): Entity[] {
+  const text = readFileSync(path.join(SEED_DIR, file), 'utf8');
+  return parseAllDocuments(text).map(d => d.toJS() as Entity);
+}
+
+const SECURITY_OWNER = 'group:default/security-reviewers';
+
+describe('catalog/seed — security-owner annotation and owners (ADR-0008)', () => {
+  const aragonIdp = loadEntities('system-aragon-idp.yaml');
+  const portalCiudadano = loadEntities('system-portal-ciudadano.yaml');
+  const all = [...aragonIdp, ...portalCiudadano];
+  const byName = new Map(all.map(e => [e.metadata.name, e]));
+
+  it('contains exactly the 4 expected seed entities', () => {
+    expect(all.map(e => e.metadata.name).sort()).toEqual(
+      [
+        'aragon-idp',
+        'portal-ciudadano',
+        'portal-ciudadano-backend',
+        'portal-ciudadano-frontend',
+      ].sort(),
+    );
+  });
+
+  it('every seed entity carries aragon.es/security-owner = security-reviewers', () => {
+    for (const e of all) {
+      expect(e.metadata.annotations?.['aragon.es/security-owner']).toBe(
+        SECURITY_OWNER,
+      );
+    }
+  });
+
+  it('Components are owned by equipo-frontend (renamed from developers)', () => {
+    const frontend = byName.get('portal-ciudadano-frontend');
+    const backend = byName.get('portal-ciudadano-backend');
+    expect(frontend?.spec.owner).toBe('group:equipo-frontend');
+    expect(backend?.spec.owner).toBe('group:equipo-frontend');
+  });
+
+  it('Systems keep platform-admins as technical owner', () => {
+    expect(byName.get('aragon-idp')?.spec.owner).toBe('group:platform-admins');
+    expect(byName.get('portal-ciudadano')?.spec.owner).toBe(
+      'group:platform-admins',
+    );
+  });
+
+  it('seed entities validate against their backstage schemas', async () => {
+    for (const e of all) {
+      const validator =
+        e.kind === 'System'
+          ? systemEntityV1alpha1Validator
+          : componentEntityV1alpha1Validator;
+      await expect(validator.check(e)).resolves.toBeTruthy();
+    }
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -17005,6 +17005,7 @@ __metadata:
     better-sqlite3: "npm:^12.0.0"
     node-gyp: "npm:^10.0.0"
     pg: "npm:^8.11.3"
+    yaml: "npm:^2.8.2"
   languageName: unknown
   linkType: soft
 
@@ -35189,7 +35190,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.2.2":
+"yaml@npm:^2.2.2, yaml@npm:^2.8.2":
   version: 2.9.0
   resolution: "yaml@npm:2.9.0"
   bin:


### PR DESCRIPTION
## Summary
- Add AST 4-level organizational hierarchy to the catalog (`catalog/seed/org-ast.yaml`)
- Rename teams (`equipo-frontend`, `equipo-spring`) and align owners across seed/templates
- Add `security-owner` annotation and align seed owners with it
- Sync Keycloak groups with `type:team` and add a group transformer for AST hierarchy
- Update catalog sync flow visual doc for renamed teams
- Document the design decisions behind the AST hierarchy as ADRs (`docs/adr/0001-0009`)

## Test plan
- [x] `keycloakGroupTransformer.test.ts`
- [x] `orgAstCatalog.test.ts`
- [x] `scaffolderTemplates.test.ts`
- [x] `seedSecurityOwner.test.ts`
- [x] `permission-policy.test.ts`