### PR TITLE
Assign the portal-ciudadano backend to equipo-spring

### DIFF
--- a/catalog/seed/system-portal-ciudadano.yaml
+++ b/catalog/seed/system-portal-ciudadano.yaml
@@ -63,7 +63,7 @@ metadata:
     aragon.es/security-owner: group:default/security-reviewers
 spec:
   type: service
-  owner: group:equipo-frontend
+  owner: group:equipo-spring
   lifecycle: production
   system: portal-ciudadano
   consumesApis:

--- a/packages/backend/src/seedSecurityOwner.test.ts
+++ b/packages/backend/src/seedSecurityOwner.test.ts
@@ -53,11 +53,11 @@ describe('catalog/seed — security-owner annotation and owners (ADR-0008)', () 
     }
   });
 
-  it('Components are owned by equipo-frontend (renamed from developers)', () => {
+  it('Components are owned by the team that maintains each one', () => {
     const frontend = byName.get('portal-ciudadano-frontend');
     const backend = byName.get('portal-ciudadano-backend');
     expect(frontend?.spec.owner).toBe('group:equipo-frontend');
-    expect(backend?.spec.owner).toBe('group:equipo-frontend');
+    expect(backend?.spec.owner).toBe('group:equipo-spring');
   });
 
   it('Systems keep platform-admins as technical owner', () => {


### PR DESCRIPTION
## Qué cambia

`portal-ciudadano-backend` pasa de `group:equipo-frontend` a `group:equipo-spring` en el seed, y la aserción y el título del test que lo fijaban se actualizan en consecuencia.

## Por qué

El backend Spring del seed estaba en `equipo-frontend` **sin intención de propiedad que preservar**: es el residuo del renombrado en bloque `developers` → `equipo-frontend` registrado en ADR-0006 (línea 49: «`catalog/seed/system-*.yaml`: revisar referencias a `developers` -> `equipo-frontend`»), que barrió todas las referencias del seed a la vez. El título del test —`Components are owned by equipo-frontend (renamed from developers)`— dejaba el accidente clavado por test.

`equipo-spring` es el `team` de nivel 4 que ya custodia la plantilla `backend-spring-boot`, así que es el equipo que mantiene este componente.

## Alcance verificado

- **Solo dos ficheros** fijaban el propietario del backend: el seed y su test. Ambos incluidos aquí.
- `docs/adr/0008` línea 22 muestra `owner: group:default/equipo-frontend`, pero en un fragmento ilustrativo genérico de la anotación `security-owner`, no ligado al backend. No se toca.
- Los ADR son registros históricos y no se modifican.
- `equipo-spring` y `equipo-frontend` mapean ambos al rol `developer` en `permission-policy.ts` (ADR-0007): **no cambia ningún permiso**.
- El frontend sigue en `equipo-frontend`; los Systems siguen en `platform-admins`.

## Tests

`toolbox run -c backstage-dev yarn workspace backend test --watchAll=false` → **8 suites, 80 tests, todo verde**.

## Contexto

Colateral de la decisión de redacción sobre dimensiones de propiedad del capítulo 3 de la memoria (ticket wayfinder T14). El seed queda coherente con lo que el capítulo afirma: `spec.owner` se asigna a equipos del último nivel y la propiedad es rastreable hasta AST, no agregada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)