### PR TITLE
Run audit store integration tests in CI against PostgreSQL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,20 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: backstage
+          POSTGRES_PASSWORD: backstage
+          POSTGRES_DB: backstage_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U backstage"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -57,6 +71,8 @@ jobs:
           cache: yarn
       - run: yarn install --immutable
       - run: yarn test:all
+        env:
+          PG_TEST_URL: postgresql://backstage:backstage@localhost:5432/backstage_test
 
   build:
     name: Build


### PR DESCRIPTION
## Problema

`plugins/audit-backend/src/AuditStore.test.ts` está **entero** envuelto en `itIfPg`, que es
`describe.skip` salvo que exista `PG_TEST_URL` (`src/testUtils.ts:6`). El workflow no definía esa
variable en ninguna línea, así que el fichero completo —282 de 2.523 líneas de código de prueba, el
segundo mayor del repositorio tras `permission-policy.test.ts`— se saltaba en silencio en cada pull
request.

## Cambio

Un bloque `services: postgres:` en el *job* `test` con `postgres:17` —la misma imagen que ya usa
`docker-compose.yml`— y `PG_TEST_URL` apuntando a él en el paso `yarn test:all`. Son 16 líneas, el
patrón estándar de contenedores de servicio de GitHub Actions.

Las credenciales son de un contenedor efímero de CI, no secretos, así que van en claro y no por
`secrets`.

## Verificación

Ejecutado en local contra un `postgres:17` recién creado, con la misma orden que corre el CI:

| | Suites | Pruebas |
|---|---|---|
| Antes (sin `PG_TEST_URL`) | 19 pasan, 1 saltada | 156 pasan, 15 saltadas |
| Después (con `PG_TEST_URL`) | **20 pasan**, 0 saltadas | **171 pasan**, 0 saltadas |

Las quince pruebas del fichero pasan a la primera: la migración a dos dialectos arranca limpia sobre
una base vacía y no aparece dependencia del orden de inserción ni desfase de zona horaria en la
columna `ts`. Coste en tiempo despreciable: 0,48 s el fichero, 12,9 s la suite entera.

Verificado además que `itIfPg` solo lo usa este fichero, de modo que encender la variable no altera
el comportamiento de ninguna otra prueba.

🤖 Generated with [Claude Code](https://claude.com/claude-code)